### PR TITLE
Fixed command overwriting issue with multiple accessories on same universe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,6 @@ dist
 .yarn/unplugged
 .yarn/build-state.yml
 .pnp.*
+
+# Ignore VS Code settings
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -92,3 +92,8 @@ In order to configure accessories (i.e., lights, light strands, etc.) you need t
 - colorOrder: The order of RGB colors. Normally, lights are ordered in RGB (red, green and then blue). If the lights are in a different order then specify their order here. If not specified, the default is 'RGB'.
 
 
+## Revision History
+
+### 1.1.16 (Jan 30, 2023)
+
+  - Fixed issue where multiple accessories using the same univserse were overwriting each others commands

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "displayName": "DMX Light",
   "name": "homebridge-dmxlight-plugin",
-  "version": "1.1.11",
+  "version": "1.1.16",
   "description": "A Homebridge plugin for controlling lights via DMX.",
   "license": "Apache-2.0",
   "repository": {
@@ -21,7 +21,8 @@
     "lint": "eslint src/**.ts --max-warnings=0",
     "watch": "npm run build && npm link && nodemon",
     "build": "rimraf ./dist && tsc",
-    "prepublishOnly": "npm run lint && npm run build"
+    "prepublishOnly": "npm run lint && npm run build",
+    "rimraf": "./node_modules/rimraf/bin.js"
   },
   "keywords": [
     "homebridge-plugin",

--- a/src/localtypings/e131.d.ts
+++ b/src/localtypings/e131.d.ts
@@ -1,8 +1,8 @@
-declare module "e131" {
+declare module 'e131' {
     class Client {
-        constructor(hostname: string, port?: number);
-        public send(packet: IPacket, callback?: () => void): void;
-        public createPacket(numSlots: number): IPacket;
+      constructor(hostname: string, port?: number);
+      public send(packet: IPacket, callback?: () => void): void;
+      public createPacket(numSlots: number): IPacket;
     }
 
     interface IPacket {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -19,7 +19,7 @@ export class DMXLightHomebridgePlatform implements DynamicPlatformPlugin {
     public readonly config: PlatformConfig,
     public readonly api: API,
   ) {
-    this.log.debug('Finished initializing platform:', this.config.name);
+    this.log.info('Finished initializing platform:', this.config.name);
 
     // When this event is fired it means Homebridge has restored all cached accessories from disk.
     // Dynamic Platform plugins should only register new accessories after this event was fired,

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -44,8 +44,9 @@ export class DMXLightPlatformAccessory {
     this.driverName = driverName;
     this.colorOrder = colorOrder;
 
-    // Create the DMX Controller object
-    this.dmxController = DmxController.getInstance(properties.serialPortName, properties.ipAddress, this.platform.log);
+    // Create the DMX Controller object and initialize it
+    this.dmxController = DmxController.getInstance(properties.serialPortName, properties.ipAddress,
+      universeNumber, driverName, this.platform.log);
 
     // set accessory information
     this.accessory.getService(this.platform.Service.AccessoryInformation)!

--- a/src/sacnUniverse.ts
+++ b/src/sacnUniverse.ts
@@ -1,0 +1,17 @@
+import { Client, IPacket } from 'e131';
+import { Logger } from 'homebridge';
+
+export class SacnUniverse {
+    sacnSlotsData: Array<number>;
+    sacnPacket: IPacket;
+
+    constructor(sacnClient: Client, universe: number, log: Logger) {
+      // Create packets to support a full universe of 512
+      this.sacnPacket = sacnClient.createPacket(512);
+      this.sacnPacket.setSourceName('DMXLightPlugin');
+      this.sacnPacket.setUniverse(universe);
+      this.sacnSlotsData = this.sacnPacket.getSlotsData();
+
+      log.info('Initialized new SACN Universe #' + universe);
+    }
+}


### PR DESCRIPTION
Fixed issue where multiple accessories using the same universe were overwriting each others commands. This was specific to E131 (SACN) accessories with the same universe number but with different channel ranges.