### PR TITLE
Fix single-channel handling for transitions etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@
 This is a Homebridge platform plugin that controls DMX-based lighting control systems. The following lighting control systems have been confirmed to work but you should have luck with any sACN device:
 
 - Enttec Pro USB Compatible controllers such as the Enttec Pro or HolidayCoro Acti-Dongle.
-- Streaming ACN (E131) controllers such as the HolidayCoro Flex and Alpha Pix.
-- Chauvet DMX-AN2
+- Streaming ACN (E131) controllers such as the HolidayCoro Flex, Alpha Pix, Chauvet DMX-AN2, etc.
 
 ## Installation
 
@@ -49,7 +48,7 @@ In order to configure accessories (i.e., lights, light strands, etc.) you need t
                     "dmxStartChannel": 1,
                     "dmxChannelCount": 1,
                     "dmxUniverse": 1,
-                    "colorOrder": "rgb"
+                    "colorOrder": "w"
                 },
                 {
                     "name": "House Outline",
@@ -100,15 +99,15 @@ In order to configure accessories (i.e., lights, light strands, etc.) you need t
 
 - **dmxChannelCount**: The number of channels within the universe to control. For a single light, specify 1. If you are controlling a light strand with 100 lights then specify 100.
 
-- **colorOrder**: The order of RGB colors. Normally, lights are ordered in RGB (red, green and then blue). If the lights are in a different order then specify their order here. If not specified, the default is 'RGB'. If the lights do not support an RGB configuration (i.e., only utilize one channel) then specify "w" for the color order.
+- **colorOrder**: The order of RGB colors. Normally, lights are ordered in RGB (red, green and then blue). If the lights are in a different order then specify their order here. If not specified, the default is 'rgb'. If the lights do not support an RGB configuration (i.e., a single channel for brightness) then specify "w" for the color order.
 
-- **ipAddress**: If you are using a Streaming ACN (E131) lighting controller then specify the IP Address of the controller.
+- **ipAddress**: If you are using a sACN (E131) lighting controller then specify the IP Address of the controller.
 
-- **transitionEffect**: Specify an optional transition effect to be applied when lights are turned on or off. Transitions DO NOT apply when making color changes. Transition effects are only supported for SACN devices and do not support a 'colorOrder' configuration of "w".  Supported Effects:
+- **transitionEffect**: Specify an optional transition effect to be applied when lights are turned on or off. Transitions DO NOT apply when making color changes. Transition effects are only supported for sACN devices. If 'colorOrder' is set to "w" then only the Gradient effect will work properly, for brightness. The other transitions will give unpredictable results, as they require three-channel fixtures. Supported Effects:
 
     - **None** or **'blank'**: Do not use any transition effect
 
-    - **Gradient**: Changes from the current color to the desired color by utilizing a series of gradient color changes during the transition.
+    - **Gradient**: Changes from the current color/brightness to the desired color/brightness by utilizing a uniform "fade" transition.
 
     - **Chase**: Sets the new color one light at a time, beginning with the first light and transitioning in a linear fashion.
 
@@ -122,22 +121,30 @@ In order to configure accessories (i.e., lights, light strands, etc.) you need t
 
 ### 1.1.16 (Jan 30, 2023)
 
-  - Fixed issue where multiple accessories using the same univserse were overwriting each others commands.
+  - Fixed issue where multiple accessories using the same universe were overwriting each other's commands.
 
 ### 1.2.1 (Feb 23, 2023)
 
   - Added gradient, chase and random transition effects when lights change colors.
 
-  - Moved IP Address and Serial Port configuration into the definitino for each accessory so that multiple devices can be supported.  This is a "Breaking Change" and will require modification of the config JSON in HomeBridge.
+  - Moved IP Address and Serial Port configuration into the definition for each accessory so that multiple devices can be supported.  This is a breaking change and will require modification of the config JSON in HomeBridge.
 
 ### 1.2.4 (Jul 22, 2023)
 
- - Added support for multiple SACN devices with different IP Addresses
+ - Added support for multiple sACN devices with different IP Addresses
 
  - Added support for single-channel lights (i.e., non-RGB) using a colorOrder of 'w'. Transition effects are not supported in this configuration.
 
  - Fix Gradient (i.e., fade-in/fade-out) transition effect that was causing lights to flicker during transition.
 
- ### 1.2.4 (Jul 30, 2023)
+ ### 1.2.5 (Jul 30, 2023)
 
  - Added Enttec Pro support for single-channel lights (i.e., non-RGB) using a colorOrder of 'w'. Transition effects are not supported in this configuration.
+
+ ### 1.2.6 (Sep 23, 2023)
+
+ - Fix Gradient transition to work with single-channel sACN fixtures.
+
+ - Add proper handling of colorOrder = 'w' in index.ts.
+ 
+ - Fix Gradient "FadeIn" transition to fade to new setting from current setting instead of 0,0,0

--- a/README.md
+++ b/README.md
@@ -145,6 +145,6 @@ In order to configure accessories (i.e., lights, light strands, etc.) you need t
 
  - Fix Gradient transition to work with single-channel sACN fixtures.
 
- - Add proper handling of colorOrder = 'w' in index.ts.
+ - Add proper handling of colorOrder = 'w' in platform.ts.
  
  - Fix Gradient "FadeIn" transition to fade to new setting from current setting instead of 0,0,0

--- a/README.md
+++ b/README.md
@@ -148,3 +148,5 @@ In order to configure accessories (i.e., lights, light strands, etc.) you need t
  - Add proper handling of colorOrder = 'w' in platform.ts.
  
  - Fix Gradient "FadeIn" transition to fade to new setting from current setting instead of 0,0,0
+
+ - Still need to fix individual fixture control when multiple fixtures are defined in the same universe.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ In order to configure accessories (i.e., lights, light strands, etc.) you need t
 
  - Added Enttec Pro support for single-channel lights (i.e., non-RGB) using a colorOrder of 'w'. Transition effects are not supported in this configuration.
 
- ### 1.2.6 (Sep 23, 2023)
+ ### 1.2.7 (Dec 03, 2023)
 
  - Fix Gradient transition to work with single-channel sACN fixtures.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-dmxlight-plugin",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-dmxlight-plugin",
-      "version": "1.2.5",
+      "version": "1.2.7",
       "license": "Apache-2.0",
       "dependencies": {
         "dmx": "^0.2.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "displayName": "DMX Light",
   "name": "homebridge-dmxlight-plugin",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "description": "A Homebridge plugin for controlling lights via DMX.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/dmx.ts
+++ b/src/dmx.ts
@@ -27,6 +27,8 @@ export class DmxController {
       if (this.sacnUniverse.colorOrder === 'w') {
         singleChannel = 1;
       }
+      // Internally we will treat single-channel as standard rgb, using the 'r' value for all three, 
+      // so transitions will work properly, but the setSacnColor function will only send the first value.
 
       if (serialPort !== '') {
         // Configure Enttec Pro
@@ -46,16 +48,11 @@ export class DmxController {
       // Initialize SACN Universe if necessary
       this.sacnUniverse = new SacnUniverse(ipAddress, universe, channelStart, channelCount, colorOrder,
         transitionEffect, transitionEffectDuration, log);
-
     }
 
     setOn(hue: number, saturation: number, brightness: number) {
 
       const rgb = this.HSVtoRGB(hue/360, saturation/100, brightness/100);
-
-    // Internally we will treat single-channel as standard rgb, using the first value for all three, 
-    // so transitions will work for single-channel sACN fixtures.
-    // (The setSacnColor function only sends the first value for single-channel fixtures.)
         
         this.log.info('DMX On with Color: HSV=' + hue + '/' + saturation + '%/' + brightness + '%, RGB=' + rgb.r + '/' +
         rgb.g + '/' + rgb.b + ' (Universe #' + this.sacnUniverse.universe + ', Channels #' + this.sacnUniverse.channelStart + '-' +

--- a/src/dmx.ts
+++ b/src/dmx.ts
@@ -117,7 +117,7 @@ export class DmxController {
         case 'sacn':
           switch (this.sacnUniverse.transitionEffect) {
             case 'gradient':
-              this.applyFadeOutTransition(0, 0, 0);
+              this.applyFadeInTransition(0, 0, 0);
               break;
             case 'random':
               this.applyRandomTransition(0, 0, 0);
@@ -214,42 +214,6 @@ export class DmxController {
           p = 1;
         }
       this.sacnUniverse.sacnClient.send(this.sacnUniverse.sacnPacket);
-    }
-
-    // applyFadeOutTransition creates a smooth transition from the current color to off
-    private applyFadeOutTransition(r: number, g: number, b: number) {
-      const ccRGB = this.getCurrentColor();
-      const ccHSV = this.rgbToHsv(ccRGB[0], ccRGB[1], ccRGB[2]);
-
-      // If its already at the target then bail
-      if (b === ccHSV[2]) {
-        return;
-      }
-
-      const fadeInterval = Math.round(this.sacnUniverse.transitionEffectDuration/this.updateInterval);
-
-      let brightness = ccHSV[2];
-      const brightnessDelta = Math.abs(brightness - b);
-      const stepAmount = brightnessDelta / fadeInterval;
-      const interval = fadeInterval;
-
-      const timerId = setInterval(() => {
-        brightness = brightness - stepAmount;
-
-        if (brightness < 0) {
-          brightness = 0;
-        }
-
-        const rgb = this.HSVtoRGB(ccHSV[0], ccHSV[1], brightness);
-        //console.log('h=' + ccHSV[0] + ', s=' + ccHSV[1] + ', v: ' + brightness + ' | r=' + rgb.r + ', g=' + rgb.g + ', b=' + rgb.b);
-
-        this.setSacnColor(rgb.r, rgb.g, rgb.b);
-
-        if (brightness <= 0) {
-          clearTimeout(timerId);
-          return;
-        }
-      }, interval);
     }
 
     // applyFadeInTransition creates a smooth transition from current to desired color

--- a/src/dmx.ts
+++ b/src/dmx.ts
@@ -431,18 +431,6 @@ export class DmxController {
       return [red, green, blue];
     }
 
-    private setSacnSingle(amount: number) {
-      const endChannel = this.sacnUniverse.channelStart-1 + this.sacnUniverse.channelCount-1;
-      //this.log.info('Updating slots buffer from ' + (startChannel-1) + ' - ' + endChannel);
-      //this.log.info('Color set to ' + r + '/' + g + '/' + b);
-
-      for (let idx = this.sacnUniverse.channelStart-1; idx <= endChannel; idx++) {
-        this.sacnUniverse.sacnSlotsData[idx] = amount;
-      }
-
-      this.sacnUniverse.sacnClient.send(this.sacnUniverse.sacnPacket);
-    }
-
     private rgbToHsv(r: number, g: number, b: number) {
       r /= 255, g /= 255, b /= 255;
 

--- a/src/dmx.ts
+++ b/src/dmx.ts
@@ -211,8 +211,6 @@ export class DmxController {
         if (p > 3) {
           p = 1;
         }
-      }
-
       this.sacnUniverse.sacnClient.send(this.sacnUniverse.sacnPacket);
     }
 

--- a/src/dmx.ts
+++ b/src/dmx.ts
@@ -387,41 +387,41 @@ export class DmxController {
         let blue = secondChannel;
         let green = thirdChannel; 
           
-      switch (this.sacnUniverse.colorOrder.toLowerCase().substring(0, 1)) {
-        case 'r':
-          red = firstChannel;
-          break;
-        case 'g':
-          green = firstChannel;
-          break;
-        case 'b':
-          blue = firstChannel;
-          break;
-      }
+        switch (this.sacnUniverse.colorOrder.toLowerCase().substring(0, 1)) {
+            case 'r':
+              red = firstChannel;
+              break;
+            case 'g':
+              green = firstChannel;
+              break;
+            case 'b':
+              blue = firstChannel;
+              break;
+        }
 
-      switch (this.sacnUniverse.colorOrder.toLowerCase().substring(1, 2)) {
-        case 'r':
-          red = secondChannel;
-          break;
-        case 'g':
-          green = secondChannel;
-          break;
-        case 'b':
-          blue = secondChannel;
-          break;
-      }
+        switch (this.sacnUniverse.colorOrder.toLowerCase().substring(1, 2)) {
+            case 'r':
+              red = secondChannel;
+              break;
+            case 'g':
+              green = secondChannel;
+              break;
+            case 'b':
+              blue = secondChannel;
+              break;
+          }
 
-      switch (this.sacnUniverse.colorOrder.toLowerCase().substring(2, 3)) {
-        case 'r':
-          red = thirdChannel;
-          break;
-        case 'g':
-          green = thirdChannel;
-          break;
-        case 'b':
-          blue = thirdChannel;
-          break;
-      }
+          switch (this.sacnUniverse.colorOrder.toLowerCase().substring(2, 3)) {
+            case 'r':
+              red = thirdChannel;
+              break;
+            case 'g':
+              green = thirdChannel;
+              break;
+            case 'b':
+              blue = thirdChannel;
+              break;
+          }
       }
       return [red, green, blue];
     }

--- a/src/dmx.ts
+++ b/src/dmx.ts
@@ -176,7 +176,19 @@ export class DmxController {
           break;
               
         case 'sacn':
-          this.setSacnColor(colors[0], colors[1], colors[2]);
+          switch (this.sacnUniverse.transitionEffect) {
+            case 'gradient':
+              this.applyFadeInTransition(colors[0], colors[1], colors[2]);
+              break;
+            case 'random':
+              this.applyRandomTransition(colors[0], colors[1], colors[2]);
+              break;
+            case 'chase':
+              this.applyChaseTransition(colors[0], colors[1], colors[2]);
+              break;
+            default:
+                 this.setSacnColor(colors[0], colors[1], colors[2]);
+          }
           break;
       }
     }
@@ -248,12 +260,14 @@ export class DmxController {
       }, interval);
     }
 
-    // applyFadeInTransition creates a smooth transition from off to the desired color
+    // applyFadeInTransition creates a smooth transition from current to desired color
     private applyFadeInTransition(r: number, g: number, b: number) {
+      const ccRGB = this.getCurrentColor();
+      const ccHSV = this.rgbToHsv(ccRGB[0], ccRGB[1], ccRGB[2]);
       const fadeInterval = Math.round(this.sacnUniverse.transitionEffectDuration/this.updateInterval);
       const destColor = this.rgbToHsv(r, g, b);
-      let brightness = 0;
-      const brightnessDelta = destColor[2];
+      let brightness = destColor[2];
+      const brightnessDelta = brightness - ccHSV[2];
       const stepAmount = brightnessDelta / fadeInterval;
       const interval = fadeInterval;
 
@@ -262,6 +276,9 @@ export class DmxController {
 
         if (brightness > 1) {
           brightness = 1;
+        }
+        if (brightness < 0) {
+          brightness = 0;
         }
 
         const rgb = this.HSVtoRGB(destColor[0], destColor[1], brightness);

--- a/src/dmx.ts
+++ b/src/dmx.ts
@@ -28,7 +28,7 @@ export class DmxController {
         singleChannel = 1;
       }
       // Internally we will treat single-channel as standard rgb, using the 'r' value for all three, 
-      // so transitions will work properly, but the setSacnColor function will only send the first value.
+      // so gradient transition will work properly, and we limit the setSacnColor function to send only the first value.
 
       if (serialPort !== '') {
         // Configure Enttec Pro

--- a/src/dmx.ts
+++ b/src/dmx.ts
@@ -11,7 +11,8 @@ export class DmxController {
     private sacnUniverse: SacnUniverse;
     private driverName = '';
     private colorOrder = 'rgb';
-    private singleChannel = 0;
+    
+    let singleChannel = 0;
 
     // Constructor
     constructor(serialPort: string, ipAddress: string, universe: number, driverName: string,
@@ -21,6 +22,11 @@ export class DmxController {
       this.dmx = new DMX();
       this.driverName = driverName;
       this.colorOrder = colorOrder;
+        
+      // Handle single-channel operations
+      if (this.sacnUniverse.colorOrder === 'w') {
+        singleChannel = 1;
+      }
 
       if (serialPort !== '') {
         // Configure Enttec Pro
@@ -47,12 +53,6 @@ export class DmxController {
 
       const rgb = this.HSVtoRGB(hue/360, saturation/100, brightness/100);
 
-    // Handle single-channel operations
-    if (this.sacnUniverse.colorOrder === 'w') {
-        singleChannel = 1;
-    } else {
-        singleChannel = 0;
-    }
     // Internally we will treat single-channel as standard rgb, using the first value for all three, 
     // so transitions will work for single-channel sACN fixtures.
     // (The setSacnColor function only sends the first value for single-channel fixtures.)

--- a/src/dmx.ts
+++ b/src/dmx.ts
@@ -96,11 +96,7 @@ export class DmxController {
               this.applyChaseTransition(colors[0], colors[1], colors[2]);
               break;
             default:
-              if (this.sacnUniverse.colorOrder === 'w') {
-                this.setSacnSingle(255);
-              } else {
-                this.setSacnColor(colors[0], colors[1], colors[2]);
-              }
+                 this.setSacnColor(colors[0], colors[1], colors[2]);
           }
           break;
       }
@@ -136,11 +132,7 @@ export class DmxController {
               this.applyChaseTransition(0, 0, 0);
               break;
             default:
-              if (this.sacnUniverse.colorOrder === 'w') {
-                this.setSacnSingle(0);
-              } else {
                 this.setSacnColor(0, 0, 0);
-              }
           }
           break;
       }
@@ -360,6 +352,7 @@ export class DmxController {
     private mapColors(r: number, g: number, b:number, colorOrder: string) {
       const colors: number[] = [ r, g, b ];
 
+    if (singleChannel === 0) {
       if (colorOrder !== 'rgb') {
         for (let i = 0; i < colorOrder.length; i++) {
           switch (colorOrder[i]) {
@@ -375,7 +368,7 @@ export class DmxController {
           }
         }
       }
-
+    }
       return colors;
     }
 
@@ -384,6 +377,11 @@ export class DmxController {
       const secondChannel: number = this.sacnUniverse.sacnSlotsData[this.sacnUniverse.channelStart];
       const thirdChannel: number = this.sacnUniverse.sacnSlotsData[this.sacnUniverse.channelStart+1];
       let red = firstChannel;
+      blue = 0;
+      green = 0;
+
+     if (singleChannel === 0) {
+
       let blue = secondChannel;
       let green = thirdChannel;
 
@@ -423,7 +421,7 @@ export class DmxController {
           break;
       }
 
-
+                }
       return [red, green, blue];
     }
 

--- a/src/dmx.ts
+++ b/src/dmx.ts
@@ -193,7 +193,8 @@ export class DmxController {
             this.sacnUniverse.sacnSlotsData[idx] = r;
             break;
 
-            // Only update all three values for 3-channel fixtures
+            // Don't send the other two values for single-channel fixtures
+                
             if (singleChannel === 0) {
               case 2:
                 this.sacnUniverse.sacnSlotsData[idx] = g;
@@ -377,15 +378,13 @@ export class DmxController {
       const secondChannel: number = this.sacnUniverse.sacnSlotsData[this.sacnUniverse.channelStart];
       const thirdChannel: number = this.sacnUniverse.sacnSlotsData[this.sacnUniverse.channelStart+1];
       let red = firstChannel;
-
-    // For single-channel fixtures, set all three colors to the same value to allow transitions to work properly
-      if (singleChannel === 1) {
-        let blue = firstChannel;
-        let green = firstChannel;
-          
-      } else {
-        let blue = secondChannel;
-        let green = thirdChannel; 
+      let blue = firstChannel;
+      let green = firstChannel;
+    // For single-channel fixtures, leave all three colors at the same value to allow transitions to work properly
+        
+      if (singleChannel === 0) {
+        blue = secondChannel;
+        green = thirdChannel; 
           
         switch (this.sacnUniverse.colorOrder.toLowerCase().substring(0, 1)) {
             case 'r':

--- a/src/dmx.ts
+++ b/src/dmx.ts
@@ -32,7 +32,7 @@ export class DmxController {
           } );
 
         // Create a dummy sacnUniverse to fulfill class requirement
-        this.sacnUniverse = new SacnUniverse('', 0, 0, 0, '', '', 0, log);
+        this.sacnUniverse = new SacnUniverse('', 1, 1, 1, '', '', 0, log);
         return;
       }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -60,6 +60,9 @@ export class DMXLightHomebridgePlatform implements DynamicPlatformPlugin {
       colorOrder = colorOrder.toLocaleLowerCase();
 
       if (colorOrder.length !== 3) {
+        if (colorOrder === 'w') {
+          this.log.info('Single-channel fixture found.');
+        } else {
         this.log.info('An unsupported color order was found. Now using default of "rgb".');
         colorOrder = 'rgb';
       }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -61,10 +61,11 @@ export class DMXLightHomebridgePlatform implements DynamicPlatformPlugin {
 
       if (colorOrder.length !== 3) {
         if (colorOrder === 'w') {
-          this.log.info('Single-channel fixture found.');
+          this.log.info('Single-channel fixture defined.');
         } else {
-        this.log.info('An unsupported color order was found. Now using default of "rgb".');
-        colorOrder = 'rgb';
+          this.log.info('An unsupported color order was found. Now using default of "rgb".');
+          colorOrder = 'rgb';
+        }
       }
 
       let ipAddress = '';

--- a/src/sacnUniverse.ts
+++ b/src/sacnUniverse.ts
@@ -21,8 +21,9 @@ export class SacnUniverse {
         this.sacnClient = new Client('localhost');
       }
 
-      // Create packets to support a full universe of 512
-      this.sacnPacket = this.sacnClient.createPacket(512);
+      // Create packets. The buffer size should match the number of pixels needed (8 * 3 = 24) so use the channel count.
+      // If the pixel is white only, then the buffer size should equal 1 for each light.
+      this.sacnPacket = this.sacnClient.createPacket(channelCount);
       this.sacnPacket.setSourceName('DMXLightPlugin');
       this.sacnPacket.setUniverse(universe);
       this.sacnSlotsData = this.sacnPacket.getSlotsData();
@@ -34,6 +35,6 @@ export class SacnUniverse {
       this.transitionEffect = transitionEffect.toLocaleLowerCase();
       this.transitionEffectDuration = transitionEffectDuration;
 
-      log.info('Initialized new SACN Universe #' + universe);
+      log.info('Initialized new SACN Universe #' + universe + ' with ' + channelCount + ' channel(s)');
     }
 }


### PR DESCRIPTION
Basic idea is, when colorOrder=w, we only read/write one value, but treat it as RGB internally, setting all three to the same value, so at least gradient transitions work.